### PR TITLE
feat: Update CyclicalRulesListener to return the cycles-count value when converted to persistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 This is a history of changes to k13labs/clara-rules.
 
+# 1.3.4
+* Update CyclicalRulesListener to return the cycles-count value when converted to persistent.
+
 # 1.3.3
 * Upgrade to clojure 1.11.2 to fix `CVE-2024-22871`, despite not really affecting clara-rules.
 * Add clj-kondo linter updates to fix bad docstring expression.

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps/prep-lib {:alias :build
                  :fn compile-main-java
                  :ensure "target/main/classes"}
- :deps {org.clojure/clojure {:mvn/version "1.11.2"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.3"}
         org.clojure/core.cache {:mvn/version "1.1.234"}
         org.clj-commons/digest {:mvn/version "1.4.100"}
         com.github.k13labs/futurama {:mvn/version "1.0.3"}

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.k13labs</groupId>
   <artifactId>clara-rules</artifactId>
   <name>clara-rules</name>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
   <scm>
-    <tag>1.3.3</tag>
+    <tag>1.3.4</tag>
     <url>https://github.com/k13labs/clara-rules</url>
     <connection>scm:git:git://github.com/k13labs/clara-rules.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/k13labs/clara-rules.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.2</version>
+      <version>1.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.cnuernber</groupId>

--- a/src/main/clojure/clara/tools/loop_detector.clj
+++ b/src/main/clojure/clara/tools/loop_detector.clj
@@ -1,7 +1,8 @@
 (ns clara.tools.loop-detector
   (:require [clara.rules.listener :as l]
             [clara.rules.engine :as eng]
-            [clara.tools.tracing :as trace]))
+            [clara.tools.tracing :as trace])
+  (:import [clojure.lang IDeref]))
 
 ;; Although we use a single type here note that the cycles-count and the on-limit-delay fields
 ;; will be nil during the persistent state of the listener.
@@ -44,7 +45,9 @@
       @on-limit-delay)
     (swap! cycles-count inc))
   (to-persistent! [listener]
-    (CyclicalRuleListener. nil max-cycles on-limit-fn nil))
+    (CyclicalRuleListener. (if (instance? IDeref cycles-count)
+                             (deref cycles-count)
+                             cycles-count) max-cycles on-limit-fn nil))
 
   l/IPersistentEventListener
   (to-transient [listener]


### PR DESCRIPTION
This ensures that we can pull the number of cycles from the cyclical rules listener after execution so that we can get it's value.