### PR TITLE
feat: create read only rules sessions, deserialize read only sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 This is a history of changes to k13labs/clara-rules.
 
-# 1.4.1
+# 1.4.3-SNAPSHOT
+* add support for read only rules sessions, ReadOnlyLocalSession, which can only be queried.
+* make clara.rules.compiler/create-get-alphas-fn public, simplify usage.
+* add output schema to clara.rules.compiled/build-network, validation.
+* add functions rulebase->query-only-rulebase, as-read-only, and assemble-read-only in the rules-engine ns.
+* add get-tokens-map to the IMemoryReader protocol to aid in fetching the memory state of entire nodes without bindings.
+* rename the rules.platform macro `thread-local-binding` to `with-thread-local-binding`, consider replace with binding.
+* add djblue/portal to dev profile.
+
+# 1.4.2
 * update k13labs/futurama to latest version
 
 # 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 This is a history of changes to k13labs/clara-rules.
 
-# 1.4.3-SNAPSHOT
+# 1.4.3
 * add support for read only rules sessions, ReadOnlyLocalSession, which can only be queried.
 * make clara.rules.compiler/create-get-alphas-fn public, simplify usage.
 * add output schema to clara.rules.compiled/build-network, validation.

--- a/deps.edn
+++ b/deps.edn
@@ -19,6 +19,7 @@
                      org.slf4j/slf4j-api {:mvn/version "2.0.16"}
                      org.slf4j/slf4j-simple {:mvn/version "2.0.16"}
                      org.clojure/math.combinatorics {:mvn/version "0.3.0"}
+                     djblue/portal {:mvn/version "0.58.2"}
                      criterium/criterium {:mvn/version "0.4.6"}}}
 
   :app {:extra-paths ["app"]

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.k13labs</groupId>
   <artifactId>clara-rules</artifactId>
   <name>clara-rules</name>
-  <version>1.4.3-SNAPSHOT</version>
+  <version>1.4.3</version>
   <scm>
-    <tag>1.4.3-SNAPSHOT</tag>
+    <tag>1.4.3</tag>
     <url>https://github.com/k13labs/clara-rules</url>
     <connection>scm:git:git://github.com/k13labs/clara-rules.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/k13labs/clara-rules.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.k13labs</groupId>
   <artifactId>clara-rules</artifactId>
   <name>clara-rules</name>
-  <version>1.4.2</version>
+  <version>1.4.3-SNAPSHOT</version>
   <scm>
-    <tag>1.4.2</tag>
+    <tag>1.4.3-SNAPSHOT</tag>
     <url>https://github.com/k13labs/clara-rules</url>
     <connection>scm:git:git://github.com/k13labs/clara-rules.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/k13labs/clara-rules.git</developerConnection>

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1882,7 +1882,7 @@
   [fact-type roots]
   (AlphaRootsWrapper. (jeq-wrap fact-type) roots))
 
-(defn- create-get-alphas-fn
+(defn create-get-alphas-fn
   "Returns a function that given a sequence of facts,
   returns a map associating alpha nodes with the facts they accept."
   [fact-type-fn ancestors-fn alpha-roots]
@@ -1968,7 +1968,7 @@
       (comp (partial apply set/union) (juxt ancestors-fn hierarchy-fn))
       (or ancestors-fn hierarchy-fn ancestors))))
 
-(sc/defn build-network
+(sc/defn build-network :- Rulebase
   "Constructs the network from compiled beta tree and condition functions."
   [id-to-node :- schema/MutableLongHashMap
    beta-roots

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -61,6 +61,10 @@
 (def ^:private ^Map class->factory-fn-sym (java.util.Collections/synchronizedMap
                                            (WeakHashMap.)))
 
+;; This private var is used during deserialization of a rulebase or rules-session
+;; when the :read-only? option is passed, then it is bound to the *read-only* var,
+;; and the the read handlers use this value to check if the expression fns should be added.
+;; when *read-only* is false, the expre fns are added, when it is true they are excluded.
 (def ^:private ^:dynamic *read-only* false)
 
 (defn record-map-constructor-name

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -61,6 +61,8 @@
 (def ^:private ^Map class->factory-fn-sym (java.util.Collections/synchronizedMap
                                            (WeakHashMap.)))
 
+(def ^:private ^:dynamic *read-only* false)
+
 (defn record-map-constructor-name
   "Return the 'map->' prefix, factory constructor function for a Clojure record."
   [rec]
@@ -142,7 +144,8 @@
          m (read-meta rdr)]
      (cond-> (builder build-map)
        m (with-meta m)
-       add-fn add-fn))))
+       (and add-fn
+            (not *read-only*)) add-fn))))
 
 (defn- create-cached-node-handler
   ([clazz
@@ -424,7 +427,7 @@
    (create-cached-node-handler ProductionNode
                                "clara/productionnode"
                                "clara/productionnodeid"
-                               #(assoc % :rhs nil)
+                               d/rem-rhs-fn
                                d/add-rhs-fn)
 
    "clara/querynode"
@@ -436,7 +439,7 @@
    (create-cached-node-handler AlphaNode
                                "clara/alphanodeid"
                                "clara/alphanode"
-                               #(assoc % :activation nil)
+                               d/rem-alpha-fn
                                d/add-alpha-fn)
 
    "clara/rootjoinnode"
@@ -453,7 +456,7 @@
    (create-cached-node-handler ExpressionJoinNode
                                "clara/exprjoinnode"
                                "clara/exprjoinnodeid"
-                               #(assoc % :join-filter-fn nil)
+                               d/rem-join-filter-fn
                                d/add-join-filter-fn)
 
    "clara/negationnode"
@@ -465,28 +468,28 @@
    (create-cached-node-handler NegationWithJoinFilterNode
                                "clara/negationwjoinnode"
                                "clara/negationwjoinnodeid"
-                               #(assoc % :join-filter-fn nil)
+                               d/rem-join-filter-fn
                                d/add-join-filter-fn)
 
    "clara/testnode"
    (create-cached-node-handler TestNode
                                "clara/testnode"
                                "clara/testnodeid"
-                               #(assoc % :test nil)
+                               d/rem-test-fn
                                d/add-test-fn)
 
    "clara/accumnode"
    (create-cached-node-handler AccumulateNode
                                "clara/accumnode"
                                "clara/accumnodeid"
-                               #(assoc % :accumulator nil)
+                               d/rem-accumulator
                                d/add-accumulator)
 
    "clara/accumwjoinnode"
    (create-cached-node-handler AccumulateWithJoinFilterNode
                                "clara/accumwjoinnode"
                                "clara/accumwjoinnodeid"
-                               #(assoc % :accumulator nil :join-filter-fn nil)
+                               (comp d/rem-accumulator d/rem-join-filter-fn)
                                (comp d/add-accumulator d/add-join-filter-fn))
 
    "clara/ruleorderactivation"
@@ -573,9 +576,10 @@
           (fn [sources]
             (with-open [^FressianWriter wtr
                         (fres/create-writer out-stream :handlers write-handler-lookup)]
-              (pform/thread-local-binding [d/node-id->node-cache (volatile! {})
-                                           d/clj-struct-holder record-holder]
-                                          (doseq [s sources] (fres/write-object wtr s)))))]
+              (pform/with-thread-local-binding [d/node-id->node-cache (volatile! {})
+                                                d/clj-struct-holder record-holder]
+                (doseq [s sources]
+                  (fres/write-object wtr s)))))]
 
       ;; In this case there is nothing to do with memory, so just serialize immediately.
       (if (:rulebase-only? opts)
@@ -601,8 +605,9 @@
   (deserialize [_ mem-facts opts]
 
     (with-open [^FressianReader rdr (fres/create-reader in-stream :handlers read-handler-lookup)]
-      (let [{:keys [rulebase-only?
-                    base-rulebase]} opts
+      (let [{:keys [base-rulebase
+                    rulebase-only?
+                    read-only?]} opts
 
             record-holder (ArrayList.)
             ;; The rulebase should either be given from the base-session or found in
@@ -621,27 +626,29 @@
             rulebase (if maybe-base-rulebase
                        maybe-base-rulebase
                        (let [without-opts-rulebase
-                             (pform/thread-local-binding [d/node-id->node-cache (volatile! {})
-                                                          d/clj-struct-holder record-holder]
-                                                         (pform/thread-local-binding [d/node-fn-cache (-> (fres/read-object rdr)
-                                                                                                          reconstruct-expressions
-                                                                                                          (com/compile-exprs opts))]
-                                                                                     (assoc (fres/read-object rdr)
-                                                                                            :node-expr-fn-lookup
-                                                                                            (.get d/node-fn-cache))))]
-                         (d/rulebase->rulebase-with-opts without-opts-rulebase opts)))]
-
+                             (pform/with-thread-local-binding [d/node-id->node-cache (volatile! {})
+                                                               d/clj-struct-holder record-holder]
+                               (pform/with-thread-local-binding [d/node-fn-cache (-> (fres/read-object rdr)
+                                                                                     (reconstruct-expressions)
+                                                                                     (cond->
+                                                                                      (not read-only?) (com/compile-exprs opts)))]
+                                 (binding [*read-only* read-only?]
+                                   (assoc (fres/read-object rdr)
+                                          :node-expr-fn-lookup
+                                          (.get d/node-fn-cache)))))]
+                         (if read-only?
+                           (eng/rulebase->query-only-rulebase without-opts-rulebase)
+                           (d/rulebase->rulebase-with-opts without-opts-rulebase opts))))]
         (if rulebase-only?
           rulebase
-          (d/assemble-restored-session rulebase
-                                       (pform/thread-local-binding [d/clj-struct-holder record-holder
-                                                                    d/mem-facts mem-facts]
-                                                                   ;; internal memory contains facts provided by mem-facts
-                                                                   ;; thus mem-facts must be bound before the call to read
-                                                                   ;; the internal memory
-                                                                   (pform/thread-local-binding [d/mem-internal (fres/read-object rdr)]
-                                                                                               (fres/read-object rdr)))
-                                       opts))))))
+          (let [memory (pform/with-thread-local-binding [d/clj-struct-holder record-holder
+                                                         d/mem-facts mem-facts]
+                         ;; internal memory contains facts provided by mem-facts
+                         ;; thus mem-facts must be bound before the call to read
+                         ;; the internal memory
+                         (pform/with-thread-local-binding [d/mem-internal (fres/read-object rdr)]
+                           (fres/read-object rdr)))]
+            (d/assemble-restored-session rulebase memory opts)))))))
 
 (s/defn create-session-serializer
   "Creates an instance of FressianSessionSerializer which implements d/ISessionSerializer by using

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -14,7 +14,6 @@
                                    <!
                                    <!*
                                    !<!
-                                   !<!*
                                    !<!!]])
   (:import [java.util.concurrent CompletableFuture]))
 
@@ -2011,6 +2010,28 @@
             (alpha-retract root fact-group memory transport listener))
           (fire-rules-handler session opts))))))
 
+(defn- query*
+  [rulebase memory query params]
+  (let [query-node (get-in rulebase [:query-nodes query])]
+    (when (= nil query-node)
+      (platform/throw-error (str "The query " query " is invalid or not included in the rule base.")))
+    (when-not (= (into #{} (keys params)) ;; nil params should be equivalent to #{}
+                 (:param-keys query-node))
+      (platform/throw-error (str "The query " query " was not provided with the correct parameters, expected: "
+                                 (:param-keys query-node) ", provided: " (set (keys params)))))
+
+    (->> (mem/get-tokens memory query-node params)
+
+         ;; Get the bindings for each token and filter generate symbols.
+         (map (fn [{bindings :bindings}]
+
+                ;; Filter generated symbols. We check first since this is an uncommon flow.
+                (if (some #(re-find #"__gen" (name %)) (keys bindings))
+
+                  (into {} (remove (fn [[k _v]] (re-find #"__gen"  (name k)))
+                                   bindings))
+                  bindings))))))
+
 (declare ->LocalSession)
 
 (deftype LocalSession [rulebase memory transport listener get-alphas-fn pending-operations]
@@ -2087,25 +2108,7 @@
                        []))))
 
   (query [session query params]
-    (let [query-node (get-in rulebase [:query-nodes query])]
-      (when (= nil query-node)
-        (platform/throw-error (str "The query " query " is invalid or not included in the rule base.")))
-      (when-not (= (into #{} (keys params)) ;; nil params should be equivalent to #{}
-                   (:param-keys query-node))
-        (platform/throw-error (str "The query " query " was not provided with the correct parameters, expected: "
-                                   (:param-keys query-node) ", provided: " (set (keys params)))))
-
-      (->> (mem/get-tokens memory query-node params)
-
-           ;; Get the bindings for each token and filter generate symbols.
-           (map (fn [{bindings :bindings}]
-
-                  ;; Filter generated symbols. We check first since this is an uncommon flow.
-                  (if (some #(re-find #"__gen" (name %)) (keys bindings))
-
-                    (into {} (remove (fn [[k v]] (re-find #"__gen"  (name k)))
-                                     bindings))
-                    bindings))))))
+    (query* rulebase memory query params))
 
   (components [session]
     {:rulebase rulebase
@@ -2137,6 +2140,52 @@
                     l/default-listener)
                   get-alphas-fn
                   []))
+
+(deftype ReadOnlyLocalSession [rulebase memory]
+  ISession
+  (insert [session facts]
+    (throw (UnsupportedOperationException. "this session is read-only")))
+  (retract [session facts]
+    (throw (UnsupportedOperationException. "this session is read-only")))
+  (fire-rules [session]
+    (throw (UnsupportedOperationException. "this session is read-only")))
+  (fire-rules [session opts]
+    (throw (UnsupportedOperationException. "this session is read-only")))
+  (fire-rules-async [session]
+    (throw (UnsupportedOperationException. "this session is read-only")))
+  (fire-rules-async [session opts]
+    (throw (UnsupportedOperationException. "this session is read-only")))
+  (query [session query params]
+    (query* rulebase memory query params))
+
+  (components [session]
+    {:rulebase rulebase
+     :memory memory}))
+
+(defn assemble-ready-only
+  [{:keys [rulebase memory]}]
+  (let [{:keys [query-nodes]} rulebase
+        read-only-rulebase (assoc rulebase
+                                  :query-nodes query-nodes
+                                  :alpha-roots {}
+                                  :beta-roots []
+                                  :productions #{}
+                                  :production-nodes []
+                                  :id-to-node {}
+                                  :node-expr-fn-lookup {}
+                                  :activation-group-sort-fn nil
+                                  :activation-group-fn nil
+                                  :get-alphas-fn nil)
+        query-node-set (set (vals query-nodes))
+        query-beta-memory (into {}
+                                (for [query-node query-node-set]
+                                  [(:id query-node) (mem/get-tokens-map memory query-node)]))
+        read-only-memory (mem/map->PersistentLocalMemory {:beta-memory query-beta-memory})]
+    (ReadOnlyLocalSession. read-only-rulebase read-only-memory)))
+
+(defn as-read-only
+  [session]
+  (assemble-ready-only (components session)))
 
 (defn with-listener
   "Return a new session with the listener added to the provided session,

--- a/src/main/clojure/clara/rules/memory.clj
+++ b/src/main/clojure/clara/rules/memory.clj
@@ -33,6 +33,9 @@
   ;; Returns the tokens associated with the given node.
   (get-tokens [memory node bindings])
 
+  ;; Returns a map of all the bindings to tokens associated with the given node.
+  (get-tokens-map [memory node])
+
   ;; Returns all tokens associated with the given node, regardless of bindings
   (get-tokens-all [memory node])
 
@@ -480,6 +483,9 @@
          bindings
          []))
 
+  (get-tokens-map [memory node]
+    (get beta-memory (:id node) {}))
+
   (get-tokens-all [memory node]
     (sequence
      cat
@@ -834,6 +840,9 @@
     (get (get beta-memory (:id node) {})
          bindings
          []))
+
+  (get-tokens-map [memory node]
+    (get beta-memory (:id node) {}))
 
   (get-tokens-all [memory node]
     (sequence

--- a/src/main/clojure/clara/rules/platform.clj
+++ b/src/main/clojure/clara/rules/platform.clj
@@ -82,7 +82,7 @@
           (recur (conj! coll [(.wrapped ^JavaEqualityWrapper (.getKey e)) (persistent! (.getValue e))])))
         (persistent! coll)))))
 
-(defmacro thread-local-binding
+(defmacro with-thread-local-binding
   "Wraps given body in a try block, where it sets each given ThreadLocal binding
   and removes it in finally block."
   [bindings & body]

--- a/src/test/clojure/clara/test_fressian.clj
+++ b/src/test/clojure/clara/test_fressian.clj
@@ -17,15 +17,15 @@
   (with-open [os (java.io.ByteArrayOutputStream.)
               ^FressianWriter wtr (fres/create-writer os :handlers df/write-handler-lookup)]
     ;; Write
-    (pform/thread-local-binding [d/node-id->node-cache (volatile! {})
-                                 d/clj-struct-holder (java.util.IdentityHashMap.)]
-                                (fres/write-object wtr x))
+    (pform/with-thread-local-binding [d/node-id->node-cache (volatile! {})
+                                      d/clj-struct-holder (java.util.IdentityHashMap.)]
+      (fres/write-object wtr x))
     ;; Read
     (let [data (.toByteArray os)]
-      (pform/thread-local-binding [d/clj-struct-holder (java.util.ArrayList.)]
-                                  (with-open [is (java.io.ByteArrayInputStream. data)
-                                              ^FressianReader rdr (fres/create-reader is :handlers df/read-handler-lookup)]
-                                    (fres/read-object rdr))))))
+      (pform/with-thread-local-binding [d/clj-struct-holder (java.util.ArrayList.)]
+        (with-open [is (java.io.ByteArrayInputStream. data)
+                    ^FressianReader rdr (fres/create-reader is :handlers df/read-handler-lookup)]
+          (fres/read-object rdr))))))
 
 (defn serde [x]
   ;; Tests all serialization cases in a way that SerDe's 2 times to show that the serialization to

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2521,9 +2521,11 @@
   (let [session (-> (mk-session (rules-data/weather-rules-with-keyword-names))
                     (insert (->Temperature 15 "MCI"))
                     (insert (->WindSpeed 45 "MCI"))
-                    (fire-rules))]
+                    (fire-rules))
+        read-only-session (eng/as-read-only session)]
     (is (= [{:?fact (->ColdAndWindy 15 45)}]
-           (query session ::rules-data/find-cold-and-windy-data)))))
+           (query session ::rules-data/find-cold-and-windy-data)
+           (query read-only-session ::rules-data/find-cold-and-windy-data)))))
 
 ;;; Verify that an exception is thrown when a duplicate name is encountered.
 ;;; Note we create the session with com/mk-session*, as com/mk-session allows


### PR DESCRIPTION
# Implement Query-Only Clara Rules Session with Selective Deserialization

## Description
This PR introduces a **query-only or read-only rules session** for Clara Rules, which optimizes querying performance and enhances portability in distributed systems. By deserializing only the query nodes and associated query memory—without compiling alpha/beta nodes or production rules—this session type minimizes startup overhead for querying.

## Key Changes
1. **Selective Deserialization of Query Nodes and Memory**  
   - Enables sessions to bypass full rule compilation by loading only query-relevant nodes and memory. This reduction in compilation overhead allows for significantly faster startup times and more efficient querying, particularly in containerized environments.

## Benefits
- **Improved Query Performance**: The query-only session minimizes redundant compilation by loading only the query nodes, resulting in near-instantaneous querying on session startup.
- **Enhanced Portability**: Query-only sessions require fewer dependencies, making deployment across multiple containers and processes simpler, without needing the full Clara Rules libraries.
- **Scalability**: Lightweight, query-only sessions support multiple distributed instances querying data efficiently, enhancing the scalability of querying operations.

## Notes
This feature is designed for environments that require fast, distributed query access, reducing both compilation overhead and dependency load by only deserializing query components.