### PR TITLE
fix: don't break inspect if no accumulated facts

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-[plugins]
+[alias]
 clojure = "https://github.com/asdf-community/asdf-clojure.git"
 [tools]
 java = "graalvm-22.3.1+java11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 This is a history of changes to k13labs/clara-rules.
 
+# 1.5.1
+* do not break inspection if no accumulated facts are found
+
 # 1.5.0
 * revert thread local use and replace with dynamic vars for safely using virtual threads.
 * upgrade deps, update infinite loop tests with latest futurama library.

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -1381,8 +1381,11 @@
     ;; This being the case, we can use the downstream token to find out what binding key-value pairs were used
     ;; to create the token "stream" of which it is part.
     (let [join-bindings (-> token :bindings (select-keys (get-join-keys this)))
-          fact-bindings (-> token :bindings (select-keys new-bindings))]
-      (first (mem/get-accum-reduced memory this join-bindings (merge join-bindings fact-bindings))))))
+          fact-bindings (-> token :bindings (select-keys new-bindings))
+          accum-reduced (mem/get-accum-reduced memory this join-bindings (merge join-bindings fact-bindings))]
+      (if (not= accum-reduced ::mem/no-accum-reduced)
+        (first accum-reduced)
+        []))))
 
 (defn- filter-accum-facts
   "Run a filter on elements against a given token for constraints that are not simple hash joins."


### PR DESCRIPTION
Rules inspection can fail here:
https://github.com/k13labs/clara-rules/blob/main/src/main/clojure/clara/rules/engine.clj#L1385

If it tries to take `first` when the below `get-in` results in the default `:clara.rules.memory/no-accum-reduced`
https://github.com/k13labs/clara-rules/blob/main/src/main/clojure/clara/rules/memory.clj#L495