### PR TITLE
chore: bump hamfisted and make update-cache compatible

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,10 +2,10 @@
  :deps/prep-lib {:alias :build
                  :fn compile-main-java
                  :ensure "target/main/classes"}
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.3"}
         org.clojure/core.cache {:mvn/version "1.1.234"}
         com.github.k13labs/futurama {:mvn/version "1.3.1"}
-        com.cnuernber/ham-fisted {:mvn/version "2.029"}
+        com.cnuernber/ham-fisted {:mvn/version "2.035"}
         prismatic/schema {:mvn/version "1.4.1"}
         org.clojure/data.fressian {:mvn/version "1.1.0"}}
 

--- a/src/main/clojure/clara/rules/update_cache/core.clj
+++ b/src/main/clojure/clara/rules/update_cache/core.clj
@@ -1,6 +1,6 @@
 (ns clara.rules.update-cache.core
   (:require [ham-fisted.api :as hf])
-  (:import [ham_fisted MutList]))
+  (:import [ham_fisted MutTreeList]))
 
 ;; Record indicating pending insertion or removal of a sequence of facts.
 (defrecord PendingUpdate [type facts])
@@ -14,7 +14,7 @@
 
 ;; This cache replicates the behavior prior to https://github.com/cerner/clara-rules/issues/249,
 ;; just in a stateful object rather than a persistent data structure.
-(deftype OrderedUpdateCache [^MutList ^:unsynchronized-mutable updates]
+(deftype OrderedUpdateCache [^MutTreeList ^:unsynchronized-mutable updates]
   UpdateCache
 
   (add-insertions! [this facts]


### PR DESCRIPTION
Latest hamfisted (starting on 2.033) broke the api ([here](https://github.com/cnuernber/ham-fisted/commit/88ea9ad8323bd5fa0f5ab4829917543850508193#diff-d367f70673835c224d85a36%5B…%5D2770165afbb51f4e4c3eR542-R543)) - `mut-list` now returns `MutTreeList` instead of `MutList`