### PR TITLE
feat: read-only session changes for inspection enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This is a history of changes to gateless/clara-rules.
 
+# 1.6.0
+* ensure read-only session has rules network with noop expressions (no compilation)
+* remove unused alphas-fn from memory, it is not used nor needed, cleanup
+
 # 1.5.9
 * change use of ham-fisted MutList to private func in UpdateCache impl
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,12 +2,12 @@
  :deps/prep-lib {:alias :build
                  :fn compile-main-java
                  :ensure "target/main/classes"}
- :deps {org.clojure/clojure {:mvn/version "1.12.3"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
         org.clojure/core.cache {:mvn/version "1.1.234"}
-        com.github.gateless/futurama {:mvn/version "1.4.1"}
-        com.cnuernber/ham-fisted {:mvn/version "3.000"}
+        com.github.gateless/futurama {:mvn/version "1.4.2"}
+        com.cnuernber/ham-fisted {:mvn/version "3.006"}
         prismatic/schema {:mvn/version "1.4.1"}
-        org.clojure/data.fressian {:mvn/version "1.1.0"}}
+        org.clojure/data.fressian {:mvn/version "1.1.1"}}
 
  ;for more examples of aliases see: https://github.com/seancorfield/dot-clojure
  :aliases

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -14,8 +14,7 @@
 (comment
   (clear-ns-vars!)
   (add-tap #'println)
-  (remove-tap #'println)
-  (tap> "foobar"))
+  (remove-tap #'println))
 
 (defhierarchy foobar
   :thing/foo :thing/that

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.gateless</groupId>
   <artifactId>clara-rules</artifactId>
   <name>clara-rules</name>
-  <version>1.6.0</version>
+  <version>1.6.0-beta1</version>
   <scm>
-    <tag>1.6.0</tag>
+    <tag>1.6.0-beta1</tag>
     <url>https://github.com/gateless/clara-rules</url>
     <connection>scm:git:git://github.com/gateless/clara-rules.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/gateless/clara-rules.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.gateless</groupId>
   <artifactId>clara-rules</artifactId>
   <name>clara-rules</name>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.0</version>
   <scm>
-    <tag>1.6.0-SNAPSHOT-001</tag>
+    <tag>1.6.0</tag>
     <url>https://github.com/gateless/clara-rules</url>
     <connection>scm:git:git://github.com/gateless/clara-rules.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/gateless/clara-rules.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -22,22 +22,22 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.12.3</version>
+      <version>1.12.4</version>
     </dependency>
     <dependency>
       <groupId>com.cnuernber</groupId>
       <artifactId>ham-fisted</artifactId>
-      <version>3.000</version>
+      <version>3.006</version>
     </dependency>
     <dependency>
       <groupId>com.github.gateless</groupId>
       <artifactId>futurama</artifactId>
-      <version>1.4.1</version>
+      <version>1.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.fressian</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>prismatic</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.gateless</groupId>
   <artifactId>clara-rules</artifactId>
   <name>clara-rules</name>
-  <version>1.5.9</version>
+  <version>1.6.0-SNAPSHOT</version>
   <scm>
-    <tag>1.5.9</tag>
+    <tag>1.6.0-SNAPSHOT-001</tag>
     <url>https://github.com/gateless/clara-rules</url>
     <connection>scm:git:git://github.com/gateless/clara-rules.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/gateless/clara-rules.git</developerConnection>

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1614,7 +1614,8 @@
                       compilation-ctxs (mapv (comp second second) prepared-exprs)
                       prev-compiled-exprs (map second (:compiled grouped-exprs))
                       next-compiled-exprs (mapv vector node-expr-keys
-                                                (with-bindings (if nspace
+                                                (with-bindings (if (and nspace
+                                                                        (not read-only?))
                                                                  {#'*ns* (the-ns nspace)}
                                                                  {})
                                                   (batching-try-eval exprs compilation-ctxs)))]]

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -2106,7 +2106,7 @@
         transport (LocalTransport.)
 
         session (eng/assemble {:rulebase rulebase
-                               :memory (eng/local-memory rulebase transport activation-group-sort-fn activation-group-fn get-alphas-fn)
+                               :memory (eng/local-memory rulebase transport activation-group-sort-fn activation-group-fn)
                                :transport transport
                                :listeners (get options :listeners  [])
                                :get-alphas-fn get-alphas-fn})]

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -467,8 +467,7 @@
                 ;; Currently these do not support serialization and must be provided during deserialization via a
                 ;; base-session or they default to the standard defaults.
                 :activation-group-sort-fn nil
-                :activation-group-fn nil
-                :alphas-fn nil))))
+                :activation-group-fn nil))))
 
 (defn opts->get-alphas-fn [rulebase opts]
   (let [fact-type-fn (:fact-type-fn opts type)
@@ -493,34 +492,30 @@
          memory (eng/local-memory rulebase
                                   (clara.rules.engine.LocalTransport.)
                                   (:activation-group-sort-fn rulebase)
-                                  (:activation-group-fn rulebase)
-                                  ;; TODO: Memory doesn't seem to ever need this or use
-                                  ;; it.  Can we just remove it from memory?
-                                  (:get-alphas-fn rulebase))]
+                                  (:activation-group-fn rulebase))
+         components {:rulebase rulebase
+                     :memory memory
+                     :transport (or transport (clara.rules.engine.LocalTransport.))
+                     :listeners (or listeners [])
+                     :get-alphas-fn (:get-alphas-fn rulebase)}]
      (if read-only?
-       (eng/assemble-read-only {:rulebase rulebase
-                                :memory memory})
-       (eng/assemble {:rulebase rulebase
-                      :memory memory
-                      :transport (or transport (clara.rules.engine.LocalTransport.))
-                      :listeners (or listeners [])
-                      :get-alphas-fn (:get-alphas-fn rulebase)}))))
+       (eng/assemble-read-only components)
+       (eng/assemble components))))
 
   ([rulebase memory opts]
    (let [{:keys [listeners transport read-only?]} opts
          memory (assoc memory
                        :rulebase rulebase
                        :activation-group-sort-fn (:activation-group-sort-fn rulebase)
-                       :activation-group-fn (:activation-group-fn rulebase)
-                       :alphas-fn (:get-alphas-fn rulebase))]
+                       :activation-group-fn (:activation-group-fn rulebase))
+         components {:rulebase rulebase
+                     :memory memory
+                     :transport (or transport (clara.rules.engine.LocalTransport.))
+                     :listeners (or listeners [])
+                     :get-alphas-fn (:get-alphas-fn rulebase)}]
      (if read-only?
-       (eng/assemble-read-only {:rulebase rulebase
-                                :memory memory})
-       (eng/assemble {:rulebase rulebase
-                      :memory memory
-                      :transport (or transport (clara.rules.engine.LocalTransport.))
-                      :listeners (or listeners [])
-                      :get-alphas-fn (:get-alphas-fn rulebase)})))))
+       (eng/assemble-read-only components)
+       (eng/assemble components)))))
 
 (defn rulebase->rulebase-with-opts
   "Intended for use in rulebase deserialization implementations where these functions were stripped

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -2234,8 +2234,8 @@
 
 (defn local-memory
   "Returns a local, in-process working memory."
-  [rulebase transport activation-group-sort-fn activation-group-fn alphas-fn]
-  (let [memory (mem/to-transient (mem/local-memory rulebase activation-group-sort-fn activation-group-fn alphas-fn))]
+  [rulebase transport activation-group-sort-fn activation-group-fn]
+  (let [memory (mem/to-transient (mem/local-memory rulebase activation-group-sort-fn activation-group-fn))]
     (doseq [beta-node (:beta-roots rulebase)]
       (left-activate beta-node {} [empty-token] memory transport l/default-listener))
     (mem/to-persistent! memory)))

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -2143,9 +2143,7 @@
   (->LocalSession rulebase
                   memory
                   transport
-                  (if (> (count listeners) 0)
-                    (l/delegating-listener listeners)
-                    l/default-listener)
+                  (l/combine-listeners listeners)
                   get-alphas-fn
                   []))
 
@@ -2178,8 +2176,12 @@
      :get-alphas-fn get-alphas-fn}))
 
 (defn assemble-read-only
-  [{:keys [rulebase memory transport listener get-alphas-fn]}]
-  (ReadOnlyLocalSession. rulebase memory transport listener get-alphas-fn))
+  [{:keys [rulebase memory transport listeners get-alphas-fn]}]
+  (ReadOnlyLocalSession. rulebase
+                         memory
+                         transport
+                         (l/combine-listeners listeners)
+                         get-alphas-fn))
 
 (defn as-read-only
   [session]

--- a/src/main/clojure/clara/rules/listener.clj
+++ b/src/main/clojure/clara/rules/listener.clj
@@ -159,7 +159,8 @@
 (defn null-listener?
   "Returns true if the given listener is the null listener, false otherwise."
   [listener]
-  (instance? NullListener listener))
+  (or (instance? NullListener listener)
+      (nil? listener)))
 
 (defn get-children
   "Returns the children of a delegating listener."
@@ -174,3 +175,9 @@
   (if (null-listener? listener)
     []
     (get-children listener)))
+
+(defn ^:internal ^:no-doc combine-listeners
+  [listeners]
+  (if (> (count listeners) 0)
+    (delegating-listener listeners)
+    default-listener))

--- a/src/main/clojure/clara/rules/memory.clj
+++ b/src/main/clojure/clara/rules/memory.clj
@@ -20,10 +20,6 @@
   ;; Returns the rulebase associated with the given memory.
   (get-rulebase [memory])
 
-  ;; Returns a function that produces a map of alpha nodes to
-  ;; facts that match the type of the node
-  (get-alphas-fn [memory])
-
   ;; Returns the elements assoicated with the given node.
   (get-elements [memory node bindings])
 
@@ -455,7 +451,6 @@
 (deftype TransientLocalMemory [rulebase
                                activation-group-sort-fn
                                activation-group-fn
-                               alphas-fn
                                ^Map alpha-memory
                                ^Map beta-memory
                                ^Map accum-memory
@@ -464,8 +459,6 @@
 
   IMemoryReader
   (get-rulebase [memory] rulebase)
-
-  (get-alphas-fn [memory] alphas-fn)
 
   (get-elements [memory node bindings]
     (get (get alpha-memory (:id node) {})
@@ -802,7 +795,6 @@
       (->PersistentLocalMemory rulebase
                                activation-group-sort-fn
                                activation-group-fn
-                               alphas-fn
                                (persistent-maps persistent-vals alpha-memory)
                                (persistent-maps persistent-vals beta-memory)
                                (persistent-maps persistent-vals accum-memory)
@@ -814,7 +806,6 @@
 (defrecord PersistentLocalMemory [rulebase
                                   activation-group-sort-fn
                                   activation-group-fn
-                                  alphas-fn
                                   alpha-memory
                                   beta-memory
                                   accum-memory
@@ -822,8 +813,6 @@
                                   activation-map]
   IMemoryReader
   (get-rulebase [memory] rulebase)
-
-  (get-alphas-fn [memory] alphas-fn)
 
   (get-elements [memory node bindings]
     (get (get alpha-memory (:id node) {})
@@ -888,7 +877,6 @@
     (TransientLocalMemory. rulebase
                            activation-group-sort-fn
                            activation-group-fn
-                           alphas-fn
                            (->mutable-map alpha-memory)
                            (->mutable-map beta-memory)
                            (->mutable-map accum-memory)
@@ -902,12 +890,11 @@
 
 (defn local-memory
   "Creates an persistent local memory for the given rule base."
-  [rulebase activation-group-sort-fn activation-group-fn alphas-fn]
+  [rulebase activation-group-sort-fn activation-group-fn]
 
   (->PersistentLocalMemory rulebase
                            activation-group-sort-fn
                            activation-group-fn
-                           alphas-fn
                            (hf/hash-map)
                            (hf/hash-map)
                            (hf/hash-map)

--- a/src/test/clojure/clara/test_durability.clj
+++ b/src/test/clojure/clara/test_durability.clj
@@ -231,6 +231,11 @@
           facts (sort-by hash @(:holder mem-serializer))]
       (testing "Ensure restored read-only session"
         (is (instance? ReadOnlyLocalSession ro-restored))
+        (let [component-keys [:rulebase :memory :transport :listeners :get-alphas-fn]
+              components (eng/components ro-restored)]
+          (doseq [component-key component-keys]
+            (is (some? (get components component-key))
+                (str "Read-only restored session should have component: " component-key))))
         (is (thrown? UnsupportedOperationException
                      (fire-rules ro-restored)))
         (is (thrown? UnsupportedOperationException


### PR DESCRIPTION
- ensure read-only session has rules network with noop expressions (no compilation)
- remove unused alphas-fn from memory, it is not used nor needed, cleanup.