### PR TITLE
feat: add inspect-facts function and memorize root facts

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -9,6 +9,9 @@
                                  query
                                  mk-session
                                  clear-ns-vars!]]
+            [clara.rules.accumulators :as acc]
+            [clara.rules.engine :as eng]
+            [clara.tools.inspect :as inspect]
             [clojure.core.cache.wrapped :as cache]))
 
 (comment
@@ -26,24 +29,85 @@
   (insert! {:type :thing/result
             :value ?value}))
 
+(defrule return-a-thang
+  [?thang <- :thang/that [{:keys [value]}] (= value ?value)]
+  [?thing <- :thing/that [{:keys [value]}] (= value ?value)]
+  [?zulu <- (acc/all) :from [:zulu/that]]
+  [:test (and (some? ?thing)
+              (some? ?thang)
+              (some? ?zulu))]
+  =>
+  (insert! {:type :thang/result
+            :value ?value}))
+
 (defquery query-a-thing
   []
   [?output <- :thing/result])
 
-(defrule default-data
-  (insert-all!
-   [{:type :thing/foo
-     :value 1}
-    {:type :thing/bar
-     :value 2}
-    {:type :thing/bar
-     :value 3}]))
+(defquery query-a-thang
+  []
+  [?output <- :thang/result])
 
 (comment
-  (time
-   (-> (mk-session 'user :fact-type-fn :type)
-       (fire-rules)
-       (query query-a-thing))))
+  (do
+    (def facts1
+      [{:type :thing/foo
+        :value 1}
+       {:type :thing/bar
+        :value 2}
+       {:type :thang/that
+        :value 3}
+       {:type :zulu/that
+        :value 4}
+       {:type :zulu/that
+        :value 5}
+       {:type :unmatched-it
+        :value 100}])
+
+    (def facts2
+      [{:type :thing/that
+        :value 3}])
+
+    (def session
+      (-> (mk-session 'user :fact-type-fn :type)
+          (insert-all facts1)
+          (fire-rules)
+          (insert-all facts2)
+          (fire-rules)))
+
+    (def components
+      (eng/components session))
+
+    (def get-alphas-fn
+      (-> components :rulebase :get-alphas-fn)))
+
+  (-> components :memory keys)
+
+  (->> components :memory :alpha-memory
+       vals
+       (mapcat vals)
+       (mapcat identity)
+       (map :fact))
+  (->> components :memory :beta-memory
+       vals
+       (mapcat vals)
+       (mapcat identity)
+       (mapcat :matches)
+       (map first))
+  (->> components :memory :accum-memory
+       vals
+       (mapcat vals)
+       (mapcat vals)
+       (mapcat first))
+  (-> components :memory :production-memory)
+
+  (get-alphas-fn facts1)
+  (get-alphas-fn facts2)
+
+  (query session query-a-thing)
+  (query session query-a-thang)
+
+  (inspect/inspect-facts session))
 
 (def session-cache
   (cache/lru-cache-factory {}))

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1889,9 +1889,10 @@
 
 (defn create-get-alphas-fn
   "Returns a function that given a sequence of facts,
-  returns a map associating alpha nodes with the facts they accept."
+  returns a tuple of::
+  - a list of tuples with each containing alpha nodes and the facts they accept.
+  - a list of facts that did not match any alpha nodes."
   [fact-type-fn ancestors-fn alpha-roots]
-
   (let [;; If a customized fact-type-fn is provided,
         ;; we must use a specialized grouping function
         ;; that handles internal control types that may not
@@ -1945,27 +1946,34 @@
       :ancestors-fn wrapped-ancestors-fn}
     (fn do-get-alphas
       [facts]
-      (let [roots->facts (java.util.LinkedHashMap.)]
-        (doseq [fact facts
-                roots-group (fact-type->roots (wrapped-fact-type-fn fact))]
-          (update-roots->facts! roots->facts roots-group fact))
+      (let [roots->facts (java.util.LinkedHashMap.)
+            unmatched-facts (hf/mut-list)]
+        (doseq [fact facts]
+          ;;; For each fact, find the matching alpha roots based on its type and ancestors.
+          (if-let [match-roots (seq (fact-type->roots (wrapped-fact-type-fn fact)))]
+            (doseq [roots-group match-roots]
+              ;;; Update the map of roots to facts
+              (update-roots->facts! roots->facts roots-group fact))
+            ;;; No matching roots, add to orphans
+            (.add unmatched-facts fact)))
 
-        (let [return-list (hf/mut-list)
+        (let [matched-alphas (hf/mut-list)
               entries (.entrySet roots->facts)
               entries-it (.iterator entries)]
-         ;; We iterate over the LinkedHashMap manually to avoid potential issues described at http://dev.clojure.org/jira/browse/CLJ-1738
-         ;; where a Java iterator can return the same entry object repeatedly and mutate it after each next() call.  We use mutable lists
-         ;; for performance but wrap them in unmodifiableList to make it clear that the caller is not expected to mutate these lists.
-         ;; Since after this function returns the only reference to the fact lists will be through the unmodifiedList we can depend elsewhere
-         ;; on these lists not changing.  Since the only expected workflow with these lists is to loop through them, not add or remove elements,
-         ;; we don't gain much from using a transient (which can be efficiently converted to a persistent data structure) rather than a mutable type.
+          ;; We iterate over the LinkedHashMap manually to avoid potential issues described at http://dev.clojure.org/jira/browse/CLJ-1738
+          ;; where a Java iterator can return the same entry object repeatedly and mutate it after each next() call.  We use mutable lists
+          ;; for performance but wrap them in unmodifiableList to make it clear that the caller is not expected to mutate these lists.
+          ;; Since after this function returns the only reference to the fact lists will be through the unmodifiedList we can depend elsewhere
+          ;; on these lists not changing.  Since the only expected workflow with these lists is to loop through them, not add or remove elements,
+          ;; we don't gain much from using a transient (which can be efficiently converted to a persistent data structure)
+          ;; rather than a mutable type.
           (loop []
             (when (.hasNext entries-it)
               (let [^java.util.Map$Entry e (.next entries-it)]
-                (.add return-list [(-> e ^AlphaRootsWrapper (.getKey) (.wrapped))
-                                   (hf/persistent! (.getValue e))])
+                (.add matched-alphas [(-> e ^AlphaRootsWrapper (.getKey) (.wrapped))
+                                      (hf/persistent! (.getValue e))])
                 (recur))))
-          (hf/persistent! return-list))))))
+          [(hf/persistent! matched-alphas) (hf/persistent! unmatched-facts)])))))
 
 (defn create-ancestors-fn
   [{:keys [ancestors-fn

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1941,6 +1941,8 @@
                                                 (.add fact-list fact)
                                                 fact-list))))]
 
+    ^{:fact-type-fn wrapped-fact-type-fn
+      :ancestors-fn wrapped-ancestors-fn}
     (fn do-get-alphas
       [facts]
       (let [roots->facts (java.util.LinkedHashMap.)]
@@ -1951,12 +1953,12 @@
         (let [return-list (hf/mut-list)
               entries (.entrySet roots->facts)
               entries-it (.iterator entries)]
-          ;; We iterate over the LinkedHashMap manually to avoid potential issues described at http://dev.clojure.org/jira/browse/CLJ-1738
-          ;; where a Java iterator can return the same entry object repeatedly and mutate it after each next() call.  We use mutable lists
-          ;; for performance but wrap them in unmodifiableList to make it clear that the caller is not expected to mutate these lists.
-          ;; Since after this function returns the only reference to the fact lists will be through the unmodifiedList we can depend elsewhere
-          ;; on these lists not changing.  Since the only expected workflow with these lists is to loop through them, not add or remove elements,
-          ;; we don't gain much from using a transient (which can be efficiently converted to a persistent data structure) rather than a mutable type.
+         ;; We iterate over the LinkedHashMap manually to avoid potential issues described at http://dev.clojure.org/jira/browse/CLJ-1738
+         ;; where a Java iterator can return the same entry object repeatedly and mutate it after each next() call.  We use mutable lists
+         ;; for performance but wrap them in unmodifiableList to make it clear that the caller is not expected to mutate these lists.
+         ;; Since after this function returns the only reference to the fact lists will be through the unmodifiedList we can depend elsewhere
+         ;; on these lists not changing.  Since the only expected workflow with these lists is to loop through them, not add or remove elements,
+         ;; we don't gain much from using a transient (which can be efficiently converted to a persistent data structure) rather than a mutable type.
           (loop []
             (when (.hasNext entries-it)
               (let [^java.util.Map$Entry e (.next entries-it)]

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1889,7 +1889,7 @@
 
 (defn create-get-alphas-fn
   "Returns a function that given a sequence of facts,
-  returns a tuple of::
+  returns a tuple of:
   - a list of tuples with each containing alpha nodes and the facts they accept.
   - a list of facts that did not match any alpha nodes."
   [fact-type-fn ancestors-fn alpha-roots]

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1941,7 +1941,8 @@
                                                 (.add fact-list fact)
                                                 fact-list))))]
 
-    (fn [facts]
+    (fn do-get-alphas
+      [facts]
       (let [roots->facts (java.util.LinkedHashMap.)]
         (doseq [fact facts
                 roots-group (fact-type->roots (wrapped-fact-type-fn fact))]

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -7,7 +7,6 @@
             [clara.rules.platform :as platform]
             [clara.rules.update-cache.core :as uc]
             [clara.rules.update-cache.cancelling :as ca]
-            [ham-fisted.api :as hf]
             [futurama.core :refer [async
                                    async?
                                    async-cancelled?

--- a/src/main/clojure/clara/rules/memory.clj
+++ b/src/main/clojure/clara/rules/memory.clj
@@ -20,6 +20,9 @@
   ;; Returns the rulebase associated with the given memory.
   (get-rulebase [memory])
 
+  ;; Returns the root elements in the working memory.
+  (get-root-elements [memory])
+
   ;; Returns the elements assoicated with the given node.
   (get-elements [memory node bindings])
 
@@ -61,6 +64,12 @@
   (get-activations [memory]))
 
 (defprotocol ITransientMemory
+
+  ;; Adds working memory elements to the given working memory at the root node.
+  (add-root-elements! [memory elements])
+
+  ;; Removes working memory elements from the given working memory at the root node.
+  (remove-root-elements! [memory elements])
 
   ;; Adds working memory elements to the given working memory at the given node.
   (add-elements! [memory node join-bindings elements])
@@ -460,6 +469,9 @@
   IMemoryReader
   (get-rulebase [memory] rulebase)
 
+  (get-root-elements [memory]
+    (get-elements-all memory {:id 0}))
+
   (get-elements [memory node bindings]
     (get (get alpha-memory (:id node) {})
          bindings
@@ -517,6 +529,12 @@
           (vals activation-map)))
 
   ITransientMemory
+  (add-root-elements! [memory elements]
+    (add-elements! memory {:id 0} {} elements))
+
+  (remove-root-elements! [memory elements]
+    (remove-elements! memory {:id 0} {} elements))
+
   (add-elements! [memory node join-bindings elements]
     (hm/compute! alpha-memory (:id node)
                  (fn do-add-bem
@@ -813,6 +831,9 @@
                                   activation-map]
   IMemoryReader
   (get-rulebase [memory] rulebase)
+
+  (get-root-elements [memory]
+    (get-elements-all memory {:id 0}))
 
   (get-elements [memory node bindings]
     (get (get alpha-memory (:id node) {})

--- a/src/main/clojure/clara/rules/memory.clj
+++ b/src/main/clojure/clara/rules/memory.clj
@@ -20,10 +20,6 @@
   ;; Returns the rulebase associated with the given memory.
   (get-rulebase [memory])
 
-  ;; Returns the unmatched root element facts in the working memory,
-  ;; useful to get facts that were inserted but did not match any alpha roots.
-  (get-unmatched-root-facts [memory])
-
   ;; Returns the elements assoicated with the given node.
   (get-elements [memory node bindings])
 
@@ -466,10 +462,6 @@
   IMemoryReader
   (get-rulebase [memory] rulebase)
 
-  (get-unmatched-root-facts [memory]
-    (->> (get-elements-all memory ROOT_NODE)
-         (map :fact)))
-
   (get-elements [memory node bindings]
     (get (get alpha-memory (:id node) {})
          bindings
@@ -823,10 +815,6 @@
                                   activation-map]
   IMemoryReader
   (get-rulebase [memory] rulebase)
-
-  (get-unmatched-root-facts [memory]
-    (->> (get-elements-all memory ROOT_NODE)
-         (map :fact)))
 
   (get-elements [memory node bindings]
     (get (get alpha-memory (:id node) {})

--- a/src/main/clojure/clara/rules/platform.clj
+++ b/src/main/clojure/clara/rules/platform.clj
@@ -65,7 +65,7 @@
 (defn fact-id-wrap
   "Wraps the value with a FactIdentityWrapper"
   ^FactIdentityWrapper [value]
-  (FactIdentityWrapper. value (hash value)))
+  (FactIdentityWrapper. value (System/identityHashCode value)))
 
 (defn group-by-seq
   "Groups the items of the given coll by f to each item.  Returns a seq of tuples of the form

--- a/src/main/clojure/clara/rules/platform.clj
+++ b/src/main/clojure/clara/rules/platform.clj
@@ -47,9 +47,25 @@
   (hashCode [this] hash-code))
 
 (defn jeq-wrap
-  "wraps the value with a JavaEqualityWrapper"
+  "Wraps the value with a JavaEqualityWrapper"
   ^JavaEqualityWrapper [value]
   (JavaEqualityWrapper. value (hash value)))
+
+;;; This class wraps objects to ensure identity semantics are used for equality
+;;; and hash code. This is used in places where we want to distinguish between
+;;; different instances of equal objects, such as when comparing facts.
+;;; This class also accepts and stores the hash code, since it almost always will be used 
+;;; once and generally more than once.
+(deftype FactIdentityWrapper [wrapped ^int hash-code]
+  Object
+  (equals [this other]
+    (identical? wrapped (.wrapped ^FactIdentityWrapper other)))
+  (hashCode [this] hash-code))
+
+(defn fact-id-wrap
+  "Wraps the value with a FactIdentityWrapper"
+  ^FactIdentityWrapper [value]
+  (FactIdentityWrapper. value (hash value)))
 
 (defn group-by-seq
   "Groups the items of the given coll by f to each item.  Returns a seq of tuples of the form

--- a/src/main/clojure/clara/tools/fact_graph.clj
+++ b/src/main/clojure/clara/tools/fact_graph.clj
@@ -77,7 +77,7 @@
         ;; to be accessible without generating the entire session inspection map.  However, we want to reuse the functionality
         ;; here without the performance penalty of generating all of the inspection data for the session.  Therefore, for now
         ;; we break the privacy of the function here.  Once issue 286 is completed we should remove this private Var access.
-        fact->explanations (@#'i/gen-fact->explanations session)
+        fact->explanations (i/gen-fact->explanations session)
 
         ;; Produce tuples of the form [inserted-fact {:rule rule :explanation clara.tools.inspect.Explanation}]
         insertion-tuples (into []

--- a/src/main/clojure/clara/tools/inspect.clj
+++ b/src/main/clojure/clara/tools/inspect.clj
@@ -55,13 +55,24 @@
                           bindings :- {s/Keyword s/Any}]) ; Bound variables
 
 ;; Schema of an inspected rule session.
-(def InspectionSchema
+(def RulesInspectionSchema
   {:rule-matches {schema/Rule [Explanation]}
    :query-matches {schema/Query [Explanation]}
    :condition-matches {schema/Condition [s/Any]}
-   :insertions {schema/Rule [{:explanation Explanation :fact s/Any}]}})
+   :root-facts [s/Any]
+   :insertions {schema/Rule [{:explanation Explanation :fact s/Any}]}
+   :fact->explanations {s/Any [{:rule schema/Rule
+                                :explanation Explanation}]}
+   (s/optional-key :unfiltered-rule-matches) {schema/Rule [Explanation]}})
 
-(defn- get-condition-matches
+(def FactsInspectionSchema
+  {:rules {s/Int schema/Rule}
+   :facts [{:fact s/Any
+            (s/optional-key :rule-id) s/Int
+            (s/optional-key :bindings) {s/Keyword s/Any}
+            :fact-types [s/Any]}]})
+
+(defn get-condition-matches
   "Returns facts matching each condition"
   [nodes memory]
   (let [node-class->node-type (fn [node]
@@ -98,7 +109,7 @@
      {}
      join-node-ids)))
 
-(defn- to-explanations
+(defn to-explanations
   "Helper function to convert tokens to explanation records."
   [session tokens]
   (let [memory (-> session eng/components :memory)
@@ -145,7 +156,7 @@
   [session]
 
   (let [{:keys [memory rulebase]} (eng/components session)
-        {:keys [productions production-nodes query-nodes]} rulebase
+        {:keys [production-nodes]} rulebase
         rule-to-rule-node (into {} (for [rule-node production-nodes]
                                      [(:production rule-node) rule-node]))]
     (apply merge-with into
@@ -165,7 +176,7 @@
        This new session will not retain references to any such information previously gathered."}
   without-full-logging i/without-activation-listening)
 
-(s/defn inspect
+(s/defn inspect :- RulesInspectionSchema
   " Returns a representation of the given rule session useful to understand the
   state of the underlying rules.
 
@@ -205,9 +216,9 @@
   ...
 
   The above segment will return matches for the rule in question."
-  [session] :- InspectionSchema
+  [session]
   (let [{:keys [memory rulebase]} (eng/components session)
-        {:keys [productions production-nodes query-nodes id-to-node]} rulebase
+        {:keys [production-nodes query-nodes id-to-node]} rulebase
 
         ;; Map of queries to their nodes in the network.
         query-to-nodes (into {} (for [[query-name query-node] query-nodes]
@@ -229,6 +240,9 @@
 
                    :condition-matches (get-condition-matches (vals id-to-node) memory)
 
+                   :root-facts (for [{:keys [fact]} (mem/get-root-elements memory)]
+                                 fact)
+
                    :insertions (into {}
                                      (for [[rule rule-node] rule-to-nodes]
                                        [rule
@@ -237,13 +251,13 @@
                                               insertion insertion-group]
                                           {:explanation (first (to-explanations session [token])) :fact insertion})]))
 
-                   :fact->explanations (gen-fact->explanations session)}]
+                   :fact->explanations (into {} (gen-fact->explanations session))}]
 
     (if-let [unfiltered-rule-matches (gen-all-rule-matches session)]
       (assoc base-info :unfiltered-rule-matches unfiltered-rule-matches)
       base-info)))
 
-(defn- explain-activation
+(defn explain-activation
   "Prints a human-readable explanation of the facts and conditions that created the Rete token."
   ([explanation] (explain-activation explanation ""))
   ([explanation prefix]
@@ -353,15 +367,38 @@
                         {:name node-fn
                          :simple-name simple-fn-name}))))))
 
-(defn get-all-facts
+(s/defn inspect-facts :- FactsInspectionSchema
+  "Returns a map with all rules and their associated facts in the session.
+  - :rules - a map of rule ids to their production nodes
+  - :facts - a sequence of maps with the following keys:
+    - :fact - the fact inserted
+    - :rule-id (optional) - the id of the rule that inserted the fact,
+      absent for root facts
+    - :bindings (optional) - the bindings used to insert the fact,
+      absent for root facts
+    - :fact-types - a sequence of fact types associated with the fact,
+      including ancestors"
   [session]
-  (let [{:keys [memory rulebase]} (eng/components session)
+  (let [{:keys [memory rulebase get-alphas-fn]} (eng/components session)
+        {:keys [fact-type-fn
+                ancestors-fn]} (meta get-alphas-fn)
         {:keys [production-nodes]} rulebase
-        root-facts (->> (mem/get-root-elements memory)
-                        (map :fact))]
-    (->> (for [rule-node production-nodes
-               token (keys (mem/get-insertions-all memory rule-node))
-               insertion-group (mem/get-insertions memory rule-node token)
-               insertion insertion-group]
-           insertion)
-         (concat root-facts))))
+        root-facts (for [{:keys [fact]} (mem/get-root-elements memory)
+                         :let [fact-type (fact-type-fn fact)
+                               ancestors (ancestors-fn fact-type)]]
+                     {:fact fact
+                      :fact-types (cons fact-type ancestors)})
+        rule-nodes (for [{:keys [id production]} production-nodes]
+                     [id production])
+        rule-facts (for [{:keys [id] :as rule-node} production-nodes
+                         {:keys [bindings] :as token} (keys (mem/get-insertions-all memory rule-node))
+                         insertion-group (mem/get-insertions memory rule-node token)
+                         fact insertion-group
+                         :let [fact-type (fact-type-fn fact)
+                               ancestors (ancestors-fn fact-type)]]
+                     {:fact fact
+                      :rule-id id
+                      :bindings bindings
+                      :fact-types (cons fact-type ancestors)})]
+    {:rules (into {} rule-nodes)
+     :facts (concat root-facts rule-facts)}))

--- a/src/main/clojure/clara/tools/inspect.clj
+++ b/src/main/clojure/clara/tools/inspect.clj
@@ -131,7 +131,7 @@
                           (.startsWith (name k) "?__gen__"))
                         bindings))))))
 
-(defn ^:private gen-all-rule-matches
+(defn gen-all-rule-matches
   [session]
   (when-let [activation-info (i/get-activation-info session)]
     (let [grouped-info (group-by #(-> % :activation :node) activation-info)]
@@ -141,7 +141,7 @@
                     (to-explanations session (map #(-> % :activation :token) v))]))
             grouped-info))))
 
-(defn ^:private gen-fact->explanations
+(defn gen-fact->explanations
   [session]
 
   (let [{:keys [memory rulebase]} (eng/components session)
@@ -352,3 +352,16 @@
         (throw (ex-info "Unable to determine node from function"
                         {:name node-fn
                          :simple-name simple-fn-name}))))))
+
+(defn get-all-facts
+  [session]
+  (let [{:keys [memory rulebase]} (eng/components session)
+        {:keys [production-nodes]} rulebase
+        root-facts (->> (mem/get-root-elements memory)
+                        (map :fact))]
+    (->> (for [rule-node production-nodes
+               token (keys (mem/get-insertions-all memory rule-node))
+               insertion-group (mem/get-insertions memory rule-node token)
+               insertion insertion-group]
+           insertion)
+         (concat root-facts))))

--- a/src/test/clojure/clara/tools/test_inspect.clj
+++ b/src/test/clojure/clara/tools/test_inspect.clj
@@ -102,12 +102,12 @@
              (frequencies (get-in rule-dump [:condition-matches (first (:lhs cold-rule))])))
           "Condition matches test")
 
-      (is (= [{:fact (->Temperature 15 "MCI")
+      (is (= [{:fact (->Temperature 10 "MCI")
                :rule-id nil
                :bindings nil
                :fact-type Temperature
                :ancestors true}
-              {:fact (->Temperature 10 "MCI")
+              {:fact (->Temperature 15 "MCI")
                :rule-id nil
                :bindings nil
                :fact-type Temperature
@@ -140,7 +140,8 @@
                      :rule-id rule-id
                      :bindings bindings
                      :fact-type (first fact-types)
-                     :ancestors (boolean (seq (rest fact-types)))})))
+                     :ancestors (boolean (seq (rest fact-types)))})
+                  (sort-by (comp (juxt :rule-id (comp :temperature :fact))))))
           "Rule facts test")
 
       ;; Test the :fact->explanations key in the inspected session data.


### PR DESCRIPTION
## Summary

This PR enhances Clara Rules' introspection capabilities by adding memory tracking of root facts and a new `inspect-facts` function that provides comprehensive fact inspection.

## Changes

### Core Memory Enhancements
- **Track unmatched root facts in working memory** - Root elements (facts inserted directly by users) that were not matched are now stored separately from derived facts, enabling clear distinction between user-inserted and rule-generated facts
- Root facts are maintained at node ID 0 using the new `->RootElement` helper function

### New Inspection Capabilities
- **New `inspect-facts` function** (`clara.tools.inspect/inspect-facts`) - Returns a structured map containing:
  - `:rules` - map of rule IDs to their production nodes
  - `:facts` - sequence of all facts with metadata:
    - `:fact` - the actual fact value
    - `:rule-id` (optional) - ID of the rule that inserted the fact (absent for root facts)
    - `:bindings` (optional) - bindings used to insert the fact (absent for root facts)
    - `:fact-types` - sequence of fact types including ancestors
- Enhanced existing `inspect` function to include `:root-facts` in the inspection map
- Exposed fact-type and ancestors functions via metadata on `get-alphas-fn` for broader reuse

### API Improvements
- Made inspection helper functions public for better composability:
- Renamed operation types for consistency: `:insertion` → `:insert`, `:retraction` → `:retract`
- Updated schema definitions: `InspectionSchema` → `RulesInspectionSchema`, added new `FactsInspectionSchema`

## Test Coverage
Added comprehensive test coverage in `clara.tools.test-inspect` for the new `inspect-facts` function, validating both root and derived facts with their metadata.